### PR TITLE
workflow, handle missing state name

### DIFF
--- a/org-clubhouse.el
+++ b/org-clubhouse.el
@@ -500,7 +500,7 @@ If set to nil, will never create stories with labels")
           (-map (lambda (cell) (cons (cdr cell) (car cell)))
                 org-clubhouse-state-alist)))
     (or (alist-get-equal state-name inv-state-name-alist)
-        (s-upcase state-name))))
+        (if state-name (s-upcase state-name) "UNKNOWN"))))
 
 ;;;
 ;;; Prompting


### PR DESCRIPTION
For some reason, some of my stories do not appear to have state
name. This is most likely a bug (either with this mode or the
API), regardless of the missing name should be handled gracefully.

Without the if guard, I would get an error because `s-upcase` does not handle `nil`.