### PR TITLE
api, switch to v3

### DIFF
--- a/org-clubhouse.el
+++ b/org-clubhouse.el
@@ -310,7 +310,7 @@ If set to nil, will never create stories with labels")
 ;;; API integration
 ;;;
 
-(defvar org-clubhouse-base-url* "https://api.clubhouse.io/api/v2")
+(defvar org-clubhouse-base-url* "https://api.clubhouse.io/api/v3")
 
 (defun org-clubhouse-auth-url (url &optional params)
  (concat url


### PR DESCRIPTION
v1 and v2 will be deprecated on 2020-03-01. It is unclear if v2 will still be available afterward. According to https://clubhouse.io/blog/api-v3/ it **should** be a drop in replacement.

@glittershark you may want to double-check your workflow with that endpoint. It seems to be working with the functions I am using.