### PR TITLE
Allow to create story without an epic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Spacemacs
+org-clubhouse-autoloads.el
+org-clubhouse-pkg.el

--- a/org-clubhouse.el
+++ b/org-clubhouse.el
@@ -432,7 +432,7 @@ If set to nil, will never create stories with labels")
   (org-clubhouse-fetch-as-id-name-pairs "projects"))
 
 (defcache org-clubhouse-epics
-  "Returns projects as (project-id . name)"
+  "Returns epics as (epic-id . name)"
   (org-clubhouse-fetch-as-id-name-pairs "epics"))
 
 (defcache org-clubhouse-milestones
@@ -520,7 +520,7 @@ If set to nil, will never create stories with labels")
 (defun org-clubhouse-prompt-for-epic (cb)
   (ivy-read
    "Select an epic: "
-   (-map #'cdr (org-clubhouse-epics))
+   (-map #'cdr (append '((nil . "No Epic")) (org-clubhouse-epics)))
    :history 'org-clubhouse-epic-history
    :action (lambda (selected)
              (let ((epic-id
@@ -663,11 +663,11 @@ If the epics already have a CLUBHOUSE-EPIC-ID, they are filtered and ignored."
                         (org-make-link-string
                          (org-clubhouse-link-to-story story-id)
                          (number-to-string story-id)))
-
-      (org-set-property "clubhouse-epic"
-                        (org-make-link-string
-                         (org-clubhouse-link-to-epic epic-id)
-                         (alist-get epic-id (org-clubhouse-epics))))
+      (when epic-id
+            (org-set-property "clubhouse-epic"
+              (org-make-link-string
+              (org-clubhouse-link-to-epic epic-id)
+              (alist-get epic-id (org-clubhouse-epics)))))
 
       (org-set-property "clubhouse-project"
                         (org-make-link-string


### PR DESCRIPTION
While it's probably a good idea to assign epics to new stories,
depending on the methodology used by the team not everything may
warrant being attached to an epic. E.g. one-off task and what
not.