### PR TITLE
Find header if not currently at point

### DIFF
--- a/org-clubhouse.el
+++ b/org-clubhouse.el
@@ -223,9 +223,11 @@ If set to nil, will never create stories with labels")
 ;;         (org-element-find-headline)))))
 
 (defun org-element-find-headline ()
-  (let ((current-elt (org-element-at-point)))
-    (when (equal 'headline (car current-elt))
-      (cadr current-elt))))
+  (save-mark-and-excursion
+    (when (not (outline-on-heading-p)) (org-back-to-heading))
+    (let ((current-elt (org-element-at-point)))
+      (when (equal 'headline (car current-elt))
+        (cadr current-elt)))))
 
 (defun org-element-extract-clubhouse-id (elt &optional property)
   (when-let* ((clubhouse-id-link (plist-get elt (or property :CLUBHOUSE-ID))))


### PR DESCRIPTION
Creating a single story would fail if the point was not on a
header. Now the code tries to find the header for the element at
point.